### PR TITLE
Modify API to support subfigure labeling

### DIFF
--- a/elasticrow.sty
+++ b/elasticrow.sty
@@ -23,7 +23,8 @@
 \newif\ifelasticrow@fullwidth
 
 %% command for adding figures to the row
-% syntax: \elasticfigure[<caption>]{<figure_file>}
+% syntax: \elasticfigure[<options>]{<figure_file>},
+% where <options> use a key-value syntax with keys 'caption' and 'label'
 \newcommand{\elasticfigure}[2][\empty]{%
 	\elasticbox@argtoks=\expandafter{\the\elasticbox@argtoks\elasticfun[#1]{#2}}%
 }
@@ -31,6 +32,9 @@
 %% keys for the elasticrow environment
 \define@key{elasticrow@key}{width}{\setlength{\elasticrow@width}{#1}}
 \define@key{elasticrow@key}{sep}{\def\elasticrow@whitespace{#1}}
+%% keys for the elasticfigure command
+\define@key{elasticfigure@key}{caption}{\def\elasticfigure@caption{#1}}
+\define@key{elasticfigure@key}{label}{\def\elasticfigure@label{#1}}
 
 %% environment for the elastic row
 % syntax: \begin{elasticrow}[<options>],
@@ -39,7 +43,6 @@
 	\setlength{\elasticrow@width}{\elasticrowwidth}%
 	\def\elasticrow@whitespace{\elasticrowsep}%
 	\setkeys{elasticrow@key}{#1}%
-	\ifdimequal{\elasticrow@width}{\textwidth}{\elasticrow@fullwidthtrue}{\elasticrow@fullwidthfalse}%
 	\elasticbox@argtoks={}%
 }{%
 	\addtolength{\elasticrow@width}{\elasticrow@whitespace}%
@@ -61,7 +64,9 @@
 	\ifx#1\empty%
 		\includegraphics[height=\elasticrow@height]{#2}%
 	\else%
-		\subcaptionbox{#1}{\includegraphics[height=\elasticrow@height]{#2}}%
+		% Set the provided key-value pairs
+		\setkeys{elasticfigure@key}{#1}%
+		\subcaptionbox{\elasticfigure@caption\label{\elasticfigure@label}}{\includegraphics[height=\elasticrow@height]{#2}}%
 	\fi%
 	% set \elasticrow@sep for the next figures
 	% - uses \fill for full-width rows, to prevent line break due to minor width overflow

--- a/elasticrow.sty
+++ b/elasticrow.sty
@@ -20,6 +20,8 @@
 \newlength{\elasticrow@sep}
 \newsavebox{\elasticrow@box}
 \newtoks{\elasticbox@argtoks}
+\newcommand{\elasticfigure@caption}
+\newcommand{\elasticfigure@label}
 \newif\ifelasticrow@fullwidth
 
 %% command for adding figures to the row

--- a/elasticrow.tex
+++ b/elasticrow.tex
@@ -27,10 +27,17 @@ The general usage is illustrated in the following example:
 \begin{figure}[!h]
 	\centering
 	\begin{elasticrow}[width=0.75\linewidth, sep=1em]
-		\elasticfigure[Figure with an A]{example-image-a}
-		\elasticfigure[A 16x9 figure]{example-image-16x9}
+		\elasticfigure[
+			caption=Figure with an A,
+			label=fig:subfig1
+		]{example-image-a}
+		\elasticfigure[
+			caption=A 16x9 figure,
+			label=fig:subfig2
+		]{example-image-16x9}
 	\end{elasticrow}
 	\caption{Caption of the surrounding \texttt{figure} environment}
+	\label{fig:fig1}
 \end{figure}
 
 \noindent
@@ -39,13 +46,20 @@ typeset as
 	\begin{figure}[!h]
 	    \centering
 	    \begin{elasticrow}[width=0.75\linewidth, sep=1em]
-	        \elasticfigure[Figure with an A]{example-image-a}
-	        \elasticfigure[A 16x9 figure]{example-image-16x9}
+	        \elasticfigure[
+	            caption=Figure with an A,
+	            label=fig:subfig1
+	    	]{example-image-a}
+	    	\elasticfigure[
+		        caption=A 16x9 figure,
+		        label=fig:subfig2
+	    	]{example-image-16x9}
 	    \end{elasticrow}
 	    \caption{Caption of the surrounding \texttt{figure} environment}
 	\end{figure}
 \end{verbatim}
 
+, where each subfigure can be individually referenced with \verb*|Fig.~\ref{fig:subfig1}|, \verb*|Fig.~\ref{fig:subfig2}|, and \verb*|Fig.~\ref{fig:sub1}|, rendered as Fig.~\ref{fig:subfig1}, Fig.~\ref{fig:subfig2}, and Fig.~\ref{fig:fig1}.
 
 \subsection{Control parameters}
 


### PR DESCRIPTION
The elasticRow is fantastic, except sometimes when I need to reference the subfigures individually. Here the \elasticfigure is adapted to accept an optional label.